### PR TITLE
Change C# namespace to Milvus.Client

### DIFF
--- a/proto/common.proto
+++ b/proto/common.proto
@@ -8,7 +8,7 @@ option java_package = "io.milvus.grpc";
 option java_outer_classname = "CommonProto";
 option java_generate_equals_and_hash = true;
 
-option csharp_namespace = "IO.Milvus.Grpc";
+option csharp_namespace = "Milvus.Client.Grpc";
 
 import "google/protobuf/descriptor.proto";
 

--- a/proto/milvus.proto
+++ b/proto/milvus.proto
@@ -8,7 +8,7 @@ option java_package = "io.milvus.grpc";
 option java_outer_classname = "MilvusProto";
 option java_generate_equals_and_hash = true;
 
-option csharp_namespace = "IO.Milvus.Grpc";
+option csharp_namespace = "Milvus.Client.Grpc";
 
 import "common.proto";
 import "schema.proto";

--- a/proto/schema.proto
+++ b/proto/schema.proto
@@ -8,7 +8,7 @@ option java_package = "io.milvus.grpc";
 option java_outer_classname = "SchemaProto";
 option java_generate_equals_and_hash = true;
 
-option csharp_namespace = "IO.Milvus.Grpc";
+option csharp_namespace = "Milvus.Client.Grpc";
 
 import "common.proto";
 


### PR DESCRIPTION
As per offline discussions, the Milvus .NET SDK will have the nuget name and namespace Milvus.Client, which is the idiomatic .NET naming (rather than IO.Milvus).

/cc @weianweigan @stephentoub @tawalke

issue: #184