### PR TITLE
enhance: Make proto check action works for all release branches

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - master
-      - '2.2'
+      - "[0-9]+.[0-9]+"
 
 jobs:
   build:


### PR DESCRIPTION
See also #20 
Use regexp to match all release branches so that all PRs for release branches can have `ci-passed` automatically.