### PR TITLE
fix: GetLoadStateRequest/GetLoadingProgressRequest use wrong privilege

### DIFF
--- a/proto/milvus.proto
+++ b/proto/milvus.proto
@@ -1576,8 +1576,8 @@ message OperatePrivilegeRequest {
 message GetLoadingProgressRequest {
   option (common.privilege_ext_obj) = {
     object_type: Collection
-    object_privilege: PrivilegeLoad
-    object_name_index: 2
+    object_privilege: PrivilegeGetLoadingProgress
+    object_name_index: 32
   };
   // Not useful for now
   common.MsgBase base = 1;
@@ -1595,8 +1595,8 @@ message GetLoadingProgressResponse {
 message GetLoadStateRequest {
   option (common.privilege_ext_obj) = {
     object_type: Collection
-    object_privilege: PrivilegeLoad
-    object_name_index: 2
+    object_privilege: PrivilegeGetLoadState
+    object_name_index: 33
   };
   // Not useful for now
   common.MsgBase base = 1;


### PR DESCRIPTION
cause GetLoadStateRequest/GetLoadingProgressRequest use the wrong privilege `PrivilegeLoad`, so if we want grant a role the privilege to execute GetLoadState and GetLoadingProgress, we must grant `PrivilegeLoad` to the role.

This PR correct the privilege for GetLoadStateRequest/GetLoadingProgressRequest