### PR TITLE
Update README to add information about generating proto files after making changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ When we implement a new feature with new API, the following steps are recommende
 4. in SDK project, sync the milvus-proto submodule to the commit and submit a commit
 5. develop SDK and main project parallelly
 
+## To generate proto files after making changes
+
+```make generate-proto```
+
+
 ## License
 Milvus proto repo is part of LF AI & Data Milvus project under Apache License 2.0.
 


### PR DESCRIPTION
In the current README file, there is no information about generating the proto files after making changes. Milvus will take up our changes only if we generate proto files with the changes made. 