### PR TITLE
fix: Fix proto update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,18 +5,38 @@ PROTOC	:= $(shell which protoc)
 PROTOC_VER := $(shell protoc --version)
 INSTALL_PATH := $(PWD)/bin
 
+# protoc-gen-go
+PROTOC_GEN_GO_VERSION := 1.33.0
+PROTOC_GEN_GO_OUTPUT := $(shell echo | $(INSTALL_PATH)/protoc-gen-go --version 2>/dev/null)
+INSTALL_PROTOC_GEN_GO := $(findstring $(PROTOC_GEN_GO_VERSION),$(PROTOC_GEN_GO_OUTPUT))
+# protoc-gen-go-grpc
+PROTOC_GEN_GO_GRPC_VERSION := 1.3.0
+PROTOC_GEN_GO_GRPC_OUTPUT := $(shell echo | $(INSTALL_PATH)/protoc-gen-go-grpc  --version 2>/dev/null)
+INSTALL_PROTOC_GEN_GO_GRPC := $(findstring $(PROTOC_GEN_GO_GRPC_VERSION),$(PROTOC_GEN_GO_GRPC_OUTPUT))
+
 all: generate-proto
 
 build:
 	@(env bash $(PWD)/scripts/core_build.sh)
 
-generate-proto: export protoc=$(PROTOC)
+generate-proto: get-proto-deps
 generate-proto: build
 	@echo "Generate proto files"
-	@echo "Installing protoc-gen-go to ./bin" && GOBIN=$(INSTALL_PATH) go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.33.0
-	@echo "Installing protoc-gen-go-grpc to ./bin" && GOBIN=$(INSTALL_PATH)  go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.3.0
 	@(env bash $(PWD)/scripts/proto_gen_go.sh $(INSTALL_PATH))
 
 clean:
 	@echo "Cleaning up all the generated files"
 	@rm -rf cmake-build
+
+get-proto-deps:
+	@mkdir -p $(INSTALL_PATH) # make sure directory exists
+	@if [ -z "$(INSTALL_PROTOC_GEN_GO)" ]; then \
+		echo "install protoc-gen-go $(PROTOC_GEN_GO_VERSION) to $(INSTALL_PATH)" && GOBIN=$(INSTALL_PATH) go install google.golang.org/protobuf/cmd/protoc-gen-go@v$(PROTOC_GEN_GO_VERSION); \
+	else \
+		echo "protoc-gen-go@v$(PROTOC_GEN_GO_VERSION) already installed";\
+	fi
+	@if [ -z "$(INSTALL_PROTOC_GEN_GO_GRPC)" ]; then \
+		echo "install protoc-gen-go-grpc $(PROTOC_GEN_GO_GRPC_VERSION) to $(INSTALL_PATH)" && GOBIN=$(INSTALL_PATH) go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v$(PROTOC_GEN_GO_GRPC_VERSION); \
+	else \
+		echo "protoc-gen-go-grpc@v$(PROTOC_GEN_GO_GRPC_VERSION) already installed";\
+	fi

--- a/scripts/proto_gen_go.sh
+++ b/scripts/proto_gen_go.sh
@@ -16,6 +16,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symlink
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE" # if $SOURCE was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+done
+ROOT_DIR="$( cd -P "$( dirname "$SOURCE" )/.." && pwd )"
+
+PROTO_DIR=$ROOT_DIR/pkg/proto
+PROTOC_BIN=$ROOT_DIR/cmake-build/protobuf/protobuf-build/protoc
+
 SCRIPTS_DIR=$(dirname "$0")
 PROTO_DIR=$SCRIPTS_DIR/../proto/
 PROGRAM=$(basename "$0")
@@ -47,7 +58,8 @@ mkdir -p ../go-api/msgpb
 mkdir -p ../go-api/federpb
 mkdir -p ../go-api/tokenizerpb
 
-echo "$(pwd)"
+echo "protoc path: $PROTOC_BIN"
+export protoc=$PROTOC_BIN
 
 $protoc --version
 


### PR DESCRIPTION
Fix the proto update script to automatically download the correct protoc version instead of relying on the locally installed one, ensuring consistency with the version used by Milvus.

issue: https://github.com/milvus-io/milvus-proto/issues/458