### PR TITLE
enhance: [2.6] generalize hook Extension.ReportRefused into ReportAction (#587)

### DIFF
--- a/go-api/hook/hook.go
+++ b/go-api/hook/hook.go
@@ -19,7 +19,7 @@ type LogInfo interface {
 
 type Extension interface {
 	Report(info any) int
-	ReportRefused(ctx context.Context, req interface{}, resp interface{}, err error, fullMethod string) error
+	ReportAction(ctx context.Context, req interface{}, resp interface{}, err error, fullMethod string, action string) error
 }
 
 type HookContextKeyType string


### PR DESCRIPTION
pr: https://github.com/milvus-io/milvus-proto/pull/587
relate: https://github.com/milvus-io/milvus/issues/49326
## Summary
Rename `Extension.ReportRefused` to `ReportAction(..., action string)` so additional out-of-band audit events (e.g. restful-return) can be dispatched through the same entry point without further expanding the `Extension` interface.