### PR TITLE
enhance: support x.y version branches in Mergify rules

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -3,7 +3,7 @@ pull_request_rules:
     conditions:
       - or:
         - base=master
-        - base~=^2(\.\d+){1,2}$
+        - base~=^[0-9]+\.[0-9]+$
       - -status-success=DCO
     actions:
       label:
@@ -16,7 +16,7 @@ pull_request_rules:
     conditions:
       - or:
         - base=master
-        - base~=^2(\.\d+){1,2}$
+        - base~=^[0-9]+\.[0-9]+$
       - status-success=DCO
     actions:
       label:
@@ -29,7 +29,7 @@ pull_request_rules:
     conditions:
       - or:
         - base=master
-        - base~=^2(\.\d+){1,2}$
+        - base~=^[0-9]+\.[0-9]+$
       - -body~=\#[0-9]{1,6}(\s+|$)
       - -body~=https://github.com/milvus-io/milvus/issues/[0-9]{1,6}(\s+|$)
       - -body~=https://github.com/milvus-io/milvus-proto/issues/[0-9]{1,6}(\s+|$)
@@ -49,7 +49,7 @@ pull_request_rules:
         - and:
           - or:
             - base=master
-            - base~=^2(\.\d+){1,2}$
+            - base~=^[0-9]+\.[0-9]+$
           - or:
             - body~=\#[0-9]{1,6}(\s+|$)
             - body~=https://github.com/milvus-io/milvus/issues/[0-9]{1,6}(\s+|$)
@@ -66,7 +66,7 @@ pull_request_rules:
     conditions:
       - or:
         - base=master
-        - base~=^2(\.\d+){1,2}$
+        - base~=^[0-9]+\.[0-9]+$
       - title~=\[automated\]
     actions:
       label:
@@ -78,7 +78,7 @@ pull_request_rules:
     conditions:
       - or:
         - base=master
-        - base~=^2(\.\d+){1,2}$
+        - base~=^[0-9]+\.[0-9]+$
       - "status-success=Run Check Proto (3.8)"
     actions:
       label:
@@ -89,7 +89,7 @@ pull_request_rules:
     conditions:
       - or:
         - base=master
-        - base~=^2(\.\d+){1,2}$
+        - base~=^[0-9]+\.[0-9]+$
       - "status-success!=Run Check Proto (3.8)"    
     actions:
       label:


### PR DESCRIPTION
Related to #598

Allow PR automation to match numeric release branches like 3.0 instead of only 2.x.