### PR TITLE
feat: add UUID field type to DataType enum (UUID = 28)

### DIFF
--- a/go-api/schemapb/schema.pb.go
+++ b/go-api/schemapb/schema.pb.go
@@ -43,6 +43,7 @@ const (
 	DataType_Text              DataType = 25
 	DataType_Timestamptz       DataType = 26
 	DataType_Mol               DataType = 27 // Molecular data type
+	DataType_UUID              DataType = 28 // Universally Unique Identifier, stored as 16 bytes
 	DataType_BinaryVector      DataType = 100
 	DataType_FloatVector       DataType = 101
 	DataType_Float16Vector     DataType = 102
@@ -73,6 +74,7 @@ var (
 		25:  "Text",
 		26:  "Timestamptz",
 		27:  "Mol",
+		28:  "UUID",
 		100: "BinaryVector",
 		101: "FloatVector",
 		102: "Float16Vector",
@@ -100,6 +102,7 @@ var (
 		"Text":              25,
 		"Timestamptz":       26,
 		"Mol":               27,
+		"UUID":              28,
 		"BinaryVector":      100,
 		"FloatVector":       101,
 		"Float16Vector":     102,

--- a/proto/schema.proto
+++ b/proto/schema.proto
@@ -35,6 +35,7 @@ enum DataType {
   Text = 25;
   Timestamptz = 26;
   Mol = 27; // Molecular data type
+  UUID = 28; // Universally Unique Identifier, stored as 16 bytes
 
   BinaryVector = 100;
   FloatVector = 101;


### PR DESCRIPTION
## Summary

Add UUID = 28 to the DataType enum for native UUID primary key support in Milvus. UUIDs are stored as 16-byte binary values and exposed as canonical strings at the SDK boundary.

## Changes

### proto/schema.proto
- Added `UUID = 28` between `Mol (27)` and `BinaryVector (100)`

### go-api/schemapb/schema.pb.go  
- Regenerated to include `DataType_UUID = 28` constant, name map entry `28: "UUID"`, and value map entry `"UUID": 28`

## Validation
- Proto compiles successfully with `grpc_tools.protoc`
- DCO sign-off included
- Follows existing enum patterns (sequential numbering, comment documenting usage)

## Related
- milvus-io/milvus#50957: Feature request
- milvus-io/milvus#51038: Milvus implementation PR

Signed-off-by: Shreyas S Joshi <shreyasjoshi2511@gmail.com>