### PR TITLE
doc: define canonical Decimal wire encoding as 8-byte little-endian u…

### DIFF
--- a/go-api/schemapb/schema.pb.go
+++ b/go-api/schemapb/schema.pb.go
@@ -1828,8 +1828,11 @@ func (x *DoubleArray) GetData() []float64 {
 }
 
 // General-purpose byte-string array.
-// Used for: Decimal (big-endian unscaled integer, 8 or 16 bytes per element),
-// and other variable-width binary fields such as Array and raw binary blobs.
+// Used for: Decimal — each element is the signed unscaled integer
+// (value * 10^scale) encoded as exactly 8 bytes, little-endian, two's
+// complement (precision <= 18 always fits int64). Null rows carry an empty
+// bytes placeholder and are marked invalid via FieldData.valid_data.
+// Also used for other variable-width binary fields such as raw binary blobs.
 type BytesArray struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/proto/schema.proto
+++ b/proto/schema.proto
@@ -256,8 +256,11 @@ message FloatArray { repeated float data = 1; }
 message DoubleArray { repeated double data = 1; }
 
 // General-purpose byte-string array.
-// Used for: Decimal (big-endian unscaled integer, 8 or 16 bytes per element),
-// and other variable-width binary fields such as Array and raw binary blobs.
+// Used for: Decimal — each element is the signed unscaled integer
+// (value * 10^scale) encoded as exactly 8 bytes, little-endian, two's
+// complement (precision <= 18 always fits int64). Null rows carry an empty
+// bytes placeholder and are marked invalid via FieldData.valid_data.
+// Also used for other variable-width binary fields such as raw binary blobs.
 message BytesArray { repeated bytes data = 1; }
 
 message StringArray { repeated string data = 1; }


### PR DESCRIPTION
## What this changes

Settles the canonical wire encoding for the `Decimal` data type (added in #630) as a public contract:

- Each element in `ScalarField.bytes_data` is the **signed unscaled integer** (`value * 10^scale`) encoded as **exactly 8 bytes, little-endian, two's complement**. With `precision <= 18`, every value fits in an int64, so there is no 16-byte variant.
- **Null rows** carry an empty bytes placeholder and are marked via `FieldData.valid_data` — decoders must not parse placeholder bytes.
- SDKs convert between this canonical binary form and user-facing decimal strings (users pass `"19.99"`; the wire carries binary).

## Why

The previous `BytesArray` comment described Decimal as a big-endian unscaled integer of "8 or 16 bytes per element", which conflicted with the server-side implementation being reviewed in milvus-io/milvus <github.com/milvus-io/milvus/pull/51636> . Per the review discussion there, the wire format must be a single documented contract that every SDK and the server implement identically. Little-endian matches Milvus's existing internal scalar/vector binary buffers; fixed 8-byte width allows direct indexing without length prefixes.

No released client or server ever implemented the previous wording, so this is a doc clarification, not a breaking change.

## Changes

- `proto/schema.proto`: updated the `BytesArray` comment with the full encoding contract
- `go-api/schemapb/schema.pb.go`: comment synced to match (comment-only; no generated-code behavior changes)

issue: milvus-io/milvus#50956